### PR TITLE
Clean up token handling

### DIFF
--- a/omero2pandas/connect.py
+++ b/omero2pandas/connect.py
@@ -241,6 +241,8 @@ class OMEROConnection:
                             f" {self.server}:{self.port}")
             except ImportError:
                 LOGGER.info("omero_user_token not installed")
+            except AttributeError:
+                LOGGER.warning("Please update omero-user-token to >=0.3.0")
             except Exception:
                 LOGGER.error("Failed to process user token", exc_info=True)
         else:

--- a/omero2pandas/connect.py
+++ b/omero2pandas/connect.py
@@ -117,7 +117,7 @@ class OMEROConnection:
             try:
                 self.client.joinSession(self.session_key)
             except Exception as e:
-                print(f"Failed to join session: {e}")
+                print(f"Failed to join session, token may have expired: {e}")
                 self.client = None
                 return False
         elif self.username is not None:
@@ -233,7 +233,7 @@ class OMEROConnection:
             try:
                 import omero_user_token
                 LOGGER.info("Requesting token info")
-                token = omero_user_token.getter()
+                token = omero_user_token.get_token()
                 self.server, port = token[token.find('@') + 1:].split(':')
                 self.port = int(port)
                 self.session_key = token[:token.find('@')]


### PR DESCRIPTION
Using the `omero_user_token.getter()` method to load and test a token doesn't play well with Jupyter when things go wrong. This is largely because a failed test tries to shutdown the interpreter.

This PR migrates to using the new .get_token() method instead, allowing us to handle problems with the token ourselves.