### PR TITLE
Formally specify omero-user-token dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ setup(
         'pandas',
         'tqdm',
     ],
+    extras_require={
+            "token": ["omero-user-token>=0.3.0"],
+        },
     setup_requires=['pytest-runner', 'flake8'],
     tests_require=['pytest', 'flake8'],
     zip_safe=True,


### PR DESCRIPTION
Per @sbesson's suggestion, it's best to actually specify the user token version requirements  as an optional dependency.

`pip install omero2pandas[token]` should now install both `omero2pandas` plus `omero-user-token`.