### PR TITLE
Handle missing ipywidgets package

### DIFF
--- a/omero2pandas/connect.py
+++ b/omero2pandas/connect.py
@@ -278,7 +278,7 @@ def detect_jupyter():
         if importlib.util.find_spec("ipywidgets") is None:
             LOGGER.warning(
                 "Detected Jupyter environment but no ipywidgets, "
-                "cannot show interactive login dialog.")
+                "cannot show interactive login widget.")
             return False
         LOGGER.debug("Detected Jupyter environment")
         return True

--- a/omero2pandas/connect.py
+++ b/omero2pandas/connect.py
@@ -280,8 +280,7 @@ def detect_jupyter():
                 "Detected Jupyter environment but no ipywidgets, "
                 "cannot show interactive login dialog.")
             return False
-        else:
-            LOGGER.debug("Detected Jupyter environment")
+        LOGGER.debug("Detected Jupyter environment")
         return True
     return False
 

--- a/omero2pandas/connect.py
+++ b/omero2pandas/connect.py
@@ -8,6 +8,7 @@
 # support@glencoesoftware.com.
 import atexit
 import getpass
+import importlib.util
 import logging
 import weakref
 
@@ -274,7 +275,13 @@ def detect_jupyter():
         return False
     shell = get_ipython().__class__.__name__
     if shell == 'ZMQInteractiveShell':
-        LOGGER.debug("Detected Jupyter environment")
+        if importlib.util.find_spec("ipywidgets") is None:
+            LOGGER.warning(
+                "Detected Jupyter environment but no ipywidgets, "
+                "cannot show interactive login dialog.")
+            return False
+        else:
+            LOGGER.debug("Detected Jupyter environment")
         return True
     return False
 


### PR DESCRIPTION
Fixes #1 

`ipywidgets` normally comes with jupyter, but some distributions apparently lack it. This PR fixes the "jupyter detector" to revert to showing the CLI interface if notebook widgets aren't installed.

jupyter/ipywidgets aren't intended as dependencies, so we just need to robustly detect their presence.