### PR TITLE
Add mimetype check before trying to open an OriginalFile as a table

### DIFF
--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -311,6 +311,11 @@ def _get_table(conn, object_type, object_id):
     else:
         raise NotImplementedError(
             f"OMERO object of type {type(target)} is not supported")
+
+    # Check that the OriginalFile has the expected mimetype
+    if orig_file.mimetype.val != "OMERO.tables":
+        raise ValueError(f"File {orig_file.id.val} is not a valid OMERO.tables")
+
     # Load the table
     resources = conn.c.sf.sharedResources()
     data_table = resources.openTable(orig_file, _ctx=conn.SERVICE_OPTS)


### PR DESCRIPTION
The `read_table` API supports both File ID and Annotation ID as valid inputs. Currently, as long as the File Annotation/Original File exists, the library will try and open it using the underlying `openTables` API.

If the ID points to a valid OriginalFile which is not an OMERO.table, the library will currently fail with a fairly uninformative `null table as argument` exception which can have other meanings. This PR proposes a simple improvement of the end-user experience by adding a preliminary check on the mimetype of the OriginalFile.

This change should be tested using the two signatures
```
omero2pandas.read_table(file_id=id)
omero2pandas.read_table(annotation_id=id)
```
If id points at a valid OMERO.tables, the API should retrieve the table as expected. If id points at an OriginalFile which is not a table, an error message should be raised.