### PR TITLE
Preserve external sessions

### DIFF
--- a/omero2pandas/connect.py
+++ b/omero2pandas/connect.py
@@ -39,6 +39,7 @@ class OMEROConnection:
         trying to use credentials. Default True.
         """
         self.client = client
+        self.external_client = client is not None
         self.session = None
         self.gateway = None
         self.temp_session = False
@@ -85,7 +86,8 @@ class OMEROConnection:
 
     def __del__(self):
         # Make sure we close sessions on deletion.
-        self.shutdown()
+        if not self.external_client:
+            self.shutdown()
 
     @property
     def connected(self):


### PR DESCRIPTION
Scenario: User creates a connector object with `connector = omero2pandas.connect_to_omero()` or the standard API and passes that into functions like `read_table(omero_connector=connector)`. The wrapper picks up the existing connection (which can be an omero2pandas object or OMERO client) and uses it to spawn a new OMEROConnection context. That context is temporary and gets deleted when reading finishes. This deletion triggers the session shutdown process, but this shouldn't happen if the user supplied their own client.

In essence, the user-provided client object's session gets closed after using it with `read_table` or another function. Trying to use it again will fail.

To fix this we keep a note of whether the user provided a client on connector creation, and don't shut down if this is the case.

