### PR TITLE
Return FileAnnotation ID when creating table, not OriginalFile ID

### DIFF
--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -202,7 +202,7 @@ def upload_table(dataframe, table_name, parent_id, parent_type='Image',
     :param port: Port the server runs on (default 4064)
     :param username: Username for server login
     :param password: Password for server login
-    :return: File annotation ID of the new table
+    :return: File Annotation ID of the new table
     """
     with OMEROConnection(server=server, username=username, password=password,
                          port=port, client=omero_connector) as connector:

--- a/omero2pandas/upload.py
+++ b/omero2pandas/upload.py
@@ -126,13 +126,13 @@ def create_table(df, table_name, parent_id, parent_type, conn, chunk_size):
         annotation.file = orig_file
 
         link_obj.link(target_obj, annotation)
-        conn.getUpdateService().saveObject(link_obj, _ctx={
-            "omero.group": str(parent_group)})
+        link_obj = conn.getUpdateService().saveAndReturnObject(
+            link_obj, _ctx={"omero.group": str(parent_group)})
         LOGGER.info("Saved annotation link")
 
         LOGGER.info(f"Finished creating table {table_name} under "
                     f"{parent_type} {parent_id}")
-        return orig_file.id.val
+        return link_obj.child.id.val
     finally:
         if table is not None:
             table.close()


### PR DESCRIPTION
Small bug, but the upload function was returning the OriginalFile ID of a created table rather than the FileAnnotation ID. Docs suggested this should have been the annotation ID and it's much easier to get the OriginalFile from the FileAnnotation than the other way around.