### PR TITLE
Support CSV inputs for uploader, link to multiple objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Otherwise a CLI interface will be provided.
 
 This behaviour can be disabled by supplying `interactive=False` to the connect call.
 
-### Reading data
+## Reading data
 
 Several utility methods are provided for working with OMERO.tables. These all support the full range of connection modes.
 
@@ -113,7 +113,7 @@ my_dataframe.head()
 
 Returned dataframes also come with a pandas index column, representing the original row numbers from the OMERO.table.
 
-### Writing data
+## Writing data
 
 Pandas dataframes can also be written back as new OMERO.tables.
 N.b. It is currently not possible to modify a table on the server.
@@ -136,6 +136,42 @@ ann_id = omero2pandas.upload_table(my_data, "Name for table", 142, "Image")
 
 Once uploaded, the table will be accessible on OMERO.web under the file 
 annotations panel of the parent object. Using unique table names is advised.
+
+### Large Tables
+The first argument to `upload_table` can be a pandas dataframe or a path to a 
+.csv file containing the table data. In the latter case the table will be read 
+in chunks corresponding to the `chunk_size` argument. This will allow you to 
+upload tables which are too large to load into system memory.
+
+```python
+import omero2pandas
+ann_id = omero2pandas.upload_table("/path/to/my.csv", "My table", 
+                                   142, chunk_size=100)
+# Reads and uploads the file to Image 142, loading 100 lines at a time 
+```
+
+
+### Linking to additional objects
+
+Each table gets linked to a parent object determined by the `parent_id` and
+`parent_id` parameters. This becomes the main parent that the table is 
+associated with in OMERO. You can also supply the `extra_links` parameter to 
+provide extra objects to link the table to. This should be a list of 
+tuples in the format `(<target_type>, <target_id>)`.
+
+
+```python
+import omero2pandas
+ann_id = omero2pandas.upload_table(
+    "/path/to/my.csv", "My table", 142,
+    extra_links=[("Image", 101), ("Dataset", 2), ("Roi", 1923)])
+# Uploads with additional links to Image 101, Dataset 2 and ROI 1923 
+```
+
+Extra links allow OMERO.web to display the resulting table as 
+an annotation associated with multiple objects.
+
+
 
 # Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -121,21 +121,42 @@ N.b. It is currently not possible to modify a table on the server.
 Connection handling works just as it does with downloading, you can 
 provide credentials, a token or a connection object.
 
-To upload data, the user needs to specify which OMERO object the table
-will be associated with. To do this, the third and fourth arguments 
-should be the object ID and object type. Supported objects are Dataset, 
+To upload data, the user needs to specify which OMERO object(s) the table
+will be associated with. This can be achieved with the `parent_id` and 
+`parent_type` arguments. Supported objects are Dataset, 
 Well, Plate, Project, Screen and Image.
 
 ```python
 import pandas
 import omero2pandas
 my_data = pandas.read_csv("/path/to/my_data.csv")
-ann_id = omero2pandas.upload_table(my_data, "Name for table", 142, "Image")
-# Returns the annotation ID of the uploaded file object
+ann_id = omero2pandas.upload_table(my_data, "Name for table", 
+                                   parent_id=142, parent_type="Image")
+# Returns the annotation ID of the uploaded FileAnnotation object
 ```
 
 Once uploaded, the table will be accessible on OMERO.web under the file 
 annotations panel of the parent object. Using unique table names is advised.
+
+### Linking to multiple objects
+
+To link to multiple objects, you can supply a list of `(<type>, <id>)`
+tuples to the `links` parameter. The resulting table's FileAnnotation 
+will be linked to all objects in the `links` parameter (plus 
+`parent_type`:`parent_id` if provided).
+
+
+```python
+import omero2pandas
+ann_id = omero2pandas.upload_table(
+    "/path/to/my.csv", "My table", 
+    links=[("Image", 101), ("Dataset", 2), ("Roi", 1923)])
+# Uploads with Annotation links to Image 101, Dataset 2 and ROI 1923 
+```
+
+Links allow OMERO.web to display the resulting table as 
+an annotation associated with those objects.
+
 
 ### Large Tables
 The first argument to `upload_table` can be a pandas dataframe or a path to a 
@@ -150,26 +171,11 @@ ann_id = omero2pandas.upload_table("/path/to/my.csv", "My table",
 # Reads and uploads the file to Image 142, loading 100 lines at a time 
 ```
 
+The `chunk_size` argument sets how many rows to send with each call to the server. 
+If not specified, omero2pandas will attempt to automatically optimise chunk 
+size to send ~2 million table cells per call (up to a max of 50,000 
+rows per message for narrow tables).
 
-### Linking to additional objects
-
-Each table gets linked to a parent object determined by the `parent_id` and
-`parent_id` parameters. This becomes the main parent that the table is 
-associated with in OMERO. You can also supply the `extra_links` parameter to 
-provide extra objects to link the table to. This should be a list of 
-tuples in the format `(<target_type>, <target_id>)`.
-
-
-```python
-import omero2pandas
-ann_id = omero2pandas.upload_table(
-    "/path/to/my.csv", "My table", 142,
-    extra_links=[("Image", 101), ("Dataset", 2), ("Roi", 1923)])
-# Uploads with additional links to Image 101, Dataset 2 and ROI 1923 
-```
-
-Extra links allow OMERO.web to display the resulting table as 
-an annotation associated with multiple objects.
 
 
 

--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -352,7 +352,7 @@ def _get_table(conn, object_type, object_id):
 
     # Load the table
     resources = conn.c.sf.sharedResources()
-    data_table = resources.openTable(orig_file, _ctx=conn.SERVICE_OPTS)
+    data_table = resources.openTable(orig_file, conn.SERVICE_OPTS)
     conn.SERVICE_OPTS.setOmeroGroup(orig_group)
     return data_table
 

--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -183,7 +183,7 @@ def read_table(file_id=None, annotation_id=None, column_names=(), rows=None,
 
 
 def upload_table(source, table_name, parent_id, parent_type='Image',
-                 extra_links=(), chunk_size=1000, omero_connector=None,
+                 extra_links=(), chunk_size=None, omero_connector=None,
                  server=None, port=4064, username=None, password=None):
     """
     Upload a pandas dataframe to a new OMERO table.
@@ -197,7 +197,8 @@ def upload_table(source, table_name, parent_id, parent_type='Image',
     One of: Image, Dataset, Plate, Well
     :param extra_links: List of (Type, ID) tuples specifying extra objects to
     link the table to.
-    :param chunk_size: Rows to transmit to the server in a single operation
+    :param chunk_size: Rows to transmit to the server in a single operation.
+    Default: Automatically choose a size
     :param omero_connector: OMERO.client object which is already connected
     to a server. Supersedes any other connection details.
     :param server: Address of the server

--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -182,19 +182,21 @@ def read_table(file_id=None, annotation_id=None, column_names=(), rows=None,
     return df
 
 
-def upload_table(dataframe, table_name, parent_id, parent_type='Image',
-                 chunk_size=1000, omero_connector=None, server=None,
-                 port=4064, username=None, password=None):
+def upload_table(source, table_name, parent_id, parent_type='Image',
+                 extra_links=(), chunk_size=1000, omero_connector=None,
+                 server=None, port=4064, username=None, password=None):
     """
     Upload a pandas dataframe to a new OMERO table.
     For the connection, supply either an active client object or server
     credentials (not both!). If neither are provided the program will search
     for an OMERO user token on the system.
-    :param dataframe: Pandas dataframe to upload to OMERO
+    :param source: Pandas dataframe or CSV file path to upload to OMERO
     :param table_name: Name for the table on OMERO
     :param parent_id: Object ID to attach the table to as an annotation.
     :param parent_type: Object type to attach to.
     One of: Image, Dataset, Plate, Well
+    :param extra_links: List of (Type, ID) tuples specifying extra objects to
+    link the table to.
     :param chunk_size: Rows to transmit to the server in a single operation
     :param omero_connector: OMERO.client object which is already connected
     to a server. Supersedes any other connection details.
@@ -208,8 +210,8 @@ def upload_table(dataframe, table_name, parent_id, parent_type='Image',
                          port=port, client=omero_connector) as connector:
         conn = connector.get_gateway()
         conn.SERVICE_OPTS.setOmeroGroup('-1')
-        ann_id = create_table(dataframe, table_name, parent_id, parent_type,
-                              conn, chunk_size)
+        ann_id = create_table(source, table_name, parent_id, parent_type,
+                              conn, chunk_size, extra_links)
         if ann_id is None:
             LOGGER.warning("Failed to create OMERO table")
         return ann_id

--- a/omero2pandas/upload.py
+++ b/omero2pandas/upload.py
@@ -8,9 +8,12 @@
 # support@glencoesoftware.com.
 import logging
 import math
+import os
+from typing import Iterable
 
 import omero
 import omero.grid
+import pandas as pd
 from tqdm.auto import tqdm
 
 LOGGER = logging.getLogger(__name__)
@@ -42,6 +45,7 @@ LINK_TYPES = {
     "Project": omero.model.ProjectAnnotationLinkI,
     "Screen": omero.model.ScreenAnnotationLinkI,
     "Well": omero.model.WellAnnotationLinkI,
+    "Roi": omero.model.RoiAnnotationLinkI,
 }
 
 OBJECT_TYPES = {
@@ -51,11 +55,13 @@ OBJECT_TYPES = {
     "Project": omero.model.ProjectI,
     "Screen": omero.model.ScreenI,
     "Well": omero.model.WellI,
+    "Roi": omero.model.RoiI,
 }
 
 
 def generate_omero_columns(df):
     omero_columns = []
+    string_columns = []
     for column_name, column_type in df.dtypes.items():
         cleaned_name = column_name.replace('/', '\\')
         if column_name in SPECIAL_NAMES and column_type.kind == 'i':
@@ -66,30 +72,67 @@ def generate_omero_columns(df):
             raise NotImplementedError(f"Column type "
                                       f"{column_type} not supported")
         if col_class == omero.grid.StringColumn:
+            string_columns.append(column_name)
             max_len = df[column_name].str.len().max()
             if math.isnan(max_len):
                 max_len = 1
             col = col_class(cleaned_name, "", int(max_len), [])
-            # Coerce missing values into strings
-            df[column_name].fillna('', inplace=True)
         else:
             col = col_class(cleaned_name, "", [])
         omero_columns.append(col)
-    return omero_columns
+    return omero_columns, string_columns
 
 
-def create_table(df, table_name, parent_id, parent_type, conn, chunk_size):
+def create_table(source, table_name, parent_id, parent_type, conn, chunk_size,
+                 extra_links):
+    # Make type case-insensitive
+    parent_type = parent_type.lower().capitalize()
     if parent_type not in OBJECT_TYPES:
         raise NotImplementedError(f"Type {parent_type} not "
                                   f"supported as a parent object")
+    elif parent_type == "Roi":
+        LOGGER.warning("ROI selected as the primary attachment target, "
+                       "resulting table may not be shown in OMERO.web UI.")
     parent_ob = conn.getObject(parent_type, parent_id)
     if parent_ob is None:
         raise ValueError(f"{parent_type} ID {parent_id} not found")
     parent_group = parent_ob.details.group.id.val
+    if extra_links is not None and not isinstance(extra_links, Iterable):
+        raise ValueError(f"Extra Links should be an iterable list of "
+                         f"type/id pairs, not {extra_links}")
+    link_to = []
+    for ob_type, ob_id in extra_links:
+        ob_type = ob_type.lower().capitalize()
+        if ob_type not in OBJECT_TYPES:
+            raise NotImplementedError(f"Type {ob_type} not "
+                                      f"supported as a link target")
+        if isinstance(ob_id, str):
+            assert ob_id.isdigit(), f"Object ID {ob_id} is not numeric"
+            ob_id = int(ob_id)
+        link_ob = conn.getObject(ob_type, ob_id)
+        if link_ob is None:
+            LOGGER.warning(f"{ob_type} ID {ob_id} not found, won't link")
+            continue
+        link_to.append((ob_type, ob_id))
 
-    df = df.copy()
-    orig_columns = df.columns.tolist()
-    columns = generate_omero_columns(df)
+    progress_monitor = tqdm(
+        desc="Inspecting table...", initial=1, dynamic_ncols=True,
+        bar_format='{desc}: {percentage:3.0f}%|{bar}| '
+                   '{n_fmt}/{total_fmt} rows, {elapsed} {postfix}')
+
+    if isinstance(source, str):
+        assert os.path.exists(source), f"Could not find file {source}"
+        columns, str_cols, total_rows = generate_omero_columns_csv(
+            source, chunk_size)
+        iter_data = (chunk for chunk in pd.read_csv(
+            source, chunksize=chunk_size))
+    else:
+        source = source.copy()
+        columns, str_cols = generate_omero_columns(source)
+        total_rows = len(source)
+        iter_data = (source.iloc[i:i + chunk_size]
+                     for i in range(0, len(source), chunk_size))
+
     resources = conn.c.sf.sharedResources(_ctx={
         "omero.group": str(parent_group)})
     repository_id = resources.repositories().descriptions[0].getId().getValue()
@@ -99,23 +142,20 @@ def create_table(df, table_name, parent_id, parent_type, conn, chunk_size):
         table = resources.newTable(repository_id, table_name, _ctx={
             "omero.group": str(parent_group)})
         table.initialize(columns)
-        total_to_upload = len(df)
-        slicer = range(0, total_to_upload, chunk_size)
+        progress_monitor.reset(total=total_rows)
+        progress_monitor.set_description("Uploading table to OMERO")
 
-        bar_fmt = '{desc}: {percentage:3.0f}%|{bar}| ' \
-                  '{n_fmt}/{total_fmt} rows, {elapsed} {postfix}'
-
-        chunk_iter = tqdm(desc="Uploading table to OMERO",
-                          total=total_to_upload,
-                          bar_format=bar_fmt)
-        for start in slicer:
-            to_upload = df[start:start + chunk_size]
-            for idx, column in enumerate(columns):
-                ref_name = orig_columns[idx]
-                column.values = to_upload[ref_name].tolist()
+        for chunk in iter_data:
+            if str_cols:
+                # Coerce missing values into strings
+                chunk.loc[:, str_cols] = chunk.loc[:, str_cols].fillna('')
+            for omero_column, (name, col_data) in zip(columns, chunk.items()):
+                if omero_column.name != name:
+                    LOGGER.debug("Matching", omero_column.name, name)
+                omero_column.values = col_data.tolist()
             table.addData(columns)
-            chunk_iter.update(len(to_upload))
-        chunk_iter.close()
+            progress_monitor.update(len(chunk))
+        progress_monitor.close()
 
         LOGGER.info("Table creation complete, linking to image")
         orig_file = table.getOriginalFile()
@@ -131,11 +171,68 @@ def create_table(df, table_name, parent_id, parent_type, conn, chunk_size):
         link_obj.link(target_obj, annotation)
         link_obj = conn.getUpdateService().saveAndReturnObject(
             link_obj, _ctx={"omero.group": str(parent_group)})
-        LOGGER.info("Saved annotation link")
-
+        annotation_id = link_obj.child.id.val
+        LOGGER.info(f"Uploaded as FileAnnotation {annotation_id}")
+        extra_link_objs = []
+        unloaded_ann = omero.model.FileAnnotationI(annotation_id, False)
+        for ob_type, ob_id in link_to:
+            # Construct additional links
+            link_obj = LINK_TYPES[ob_type]()
+            target_obj = OBJECT_TYPES[ob_type](ob_id, False)
+            link_obj.link(target_obj, unloaded_ann)
+            extra_link_objs.append(link_obj)
+        if extra_link_objs:
+            try:
+                conn.getUpdateService().saveArray(
+                    extra_link_objs, _ctx={"omero.group": str(parent_group)})
+                LOGGER.info(f"Added links to {len(extra_link_objs)} objects")
+            except Exception as e:
+                LOGGER.error("Failed to create extra links", exc_info=e)
         LOGGER.info(f"Finished creating table {table_name} under "
                     f"{parent_type} {parent_id}")
-        return link_obj.child.id.val
+        return annotation_id
     finally:
         if table is not None:
             table.close()
+
+
+def generate_omero_columns_csv(csv_path, chunk_size=1000):
+    LOGGER.info(f"Inspecting {csv_path}")
+    scan = pd.read_csv(csv_path, nrows=chunk_size)
+    LOGGER.debug("Shape is ", scan.shape)
+    omero_columns = []
+    to_resolve = {}
+    for idx, (column_name, column_type) in enumerate(scan.dtypes.items()):
+        cleaned_name = column_name.replace('/', '\\')
+        if column_name in SPECIAL_NAMES and column_type.kind == 'i':
+            col_class = SPECIAL_NAMES[column_name]
+        elif column_type.kind in COLUMN_TYPES:
+            col_class = COLUMN_TYPES[column_type.kind]
+        else:
+            raise NotImplementedError(f"Column type "
+                                      f"{column_type} not supported")
+        if col_class == omero.grid.StringColumn:
+            max_len = scan[column_name].str.len().max()
+            if math.isnan(max_len):
+                max_len = 1
+            col = col_class(cleaned_name, "", int(max_len), [])
+            to_resolve[column_name] = idx
+        else:
+            col = col_class(cleaned_name, "", [])
+        omero_columns.append(col)
+    LOGGER.debug(f"Generated columns, found {len(to_resolve)} string columns")
+    # Use a subset of columns to get row count and string lengths
+    use_cols = to_resolve.keys() or [0]
+    row_count = 0
+    LOGGER.info("Scanning CSV for size and column metadata")
+    for chunk in pd.read_csv(csv_path, chunksize=chunk_size, usecols=use_cols):
+        # chunk is a DataFrame. To "process" the rows in the chunk:
+        row_count += len(chunk)
+        for column_name, index in to_resolve.items():
+            max_len = chunk[column_name].str.len().max()
+            if math.isnan(max_len):
+                max_len = 1
+            max_len = int(max_len)
+            omero_columns[index].size = max(max_len, omero_columns[index].size)
+    LOGGER.info(f"Initial scan completed, found {row_count} rows")
+    return omero_columns, to_resolve.keys(), row_count


### PR DESCRIPTION
- Adds support for chunked uploading of CSVs from a file on disk.
- Adds parameter to supply extra object targets to link to
- Adds support for ROIs as the linking target. Show a warning if ROI selected as the primary target (not visible in OMERO.web)

`omero2pandas.upload_table` now supports either a pandas dataframe or CSV path as an input. With a CSV we need to establish the max length of any string columns, so we need to scan the file before uploading. Strategy is as follows:

- Grab the head/first <chunk_size> rows of the CSV file. Determine OMERO column types and identify which, if any, contain strings.
- Iterate through the entire file in chunks, loading just the string columns, so as to determine their max length. While we're at it we'll capture the row count too. Exclusively loading string columns gives us a significant performance benefit, probably since pandas isn't coercing all the numeric columns for every chunk.
- Generate the OMERO.table, iterate through the file once more in chunks, uploading as we go. 