### PR TITLE
Use connection manager for keepalives

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,24 @@ with omero2pandas.OMEROConnection(server='my.server', port=4064,
 
 The context manager will handle session creation and cleanup automatically.
 
+### Connection Management
+
+omero2pandas keeps track of any active connector objects and shuts them down 
+safely when Python exits. Deleting all references to a connector will also 
+handle closing the connection to OMERO gracefully. You can also call 
+`connector.shutdown()` to close a connection manually.
+
+By default omero2pandas also keeps active connections alive by pinging the 
+server once per minute (otherwise the session may timeout and require 
+reconnecting). This can be disabled as follows 
+
+```python
+omero2pandas.connect_to_omero(keep_alive=False)
+```
+
+N.b. omero2pandas uses a different system from the native OMERO API's
+`client.enableKeepAlive` function, using both is unnecessary.
+
 ### Querying tables
 
 You can also supply [PyTables condition syntax](https://www.pytables.org/usersguide/condition_syntax.html) to the `read_table` and `download_table` functions.

--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -377,7 +377,7 @@ def _validate_requested_object(file_id, annotation_id):
 
 def connect_to_omero(client=None, server=None, port=4064,
                      username=None, password=None, session_key=None,
-                     allow_token=True, interactive=True):
+                     allow_token=True, interactive=True, keep_alive=True):
     """
     Connect to OMERO and return an OMEROConnection object.
     :param client: An existing omero.client object to be used instead of
@@ -391,6 +391,7 @@ def connect_to_omero(client=None, server=None, port=4064,
     :param allow_token: True/False Search for omero_user_token before trying
     to use credentials. Default True.
     :param interactive: Prompt user for missing login details. Default True.
+    :param keep_alive: Periodically ping the server to prevent session timeout.
     :return: OMEROConnection object wrapping a client and Blitz Gateway object,
     with automatic session management and cleanup.
     """
@@ -398,5 +399,5 @@ def connect_to_omero(client=None, server=None, port=4064,
                                 session_key=session_key, username=username,
                                 password=password, client=client,
                                 allow_token=allow_token)
-    connector.connect(interactive=interactive)
+    connector.connect(interactive=interactive, keep_alive=keep_alive)
     return connector


### PR DESCRIPTION
Fixes #18

If you don't close sessions aggressively the omero-py keepalive system currerntly doesn't shut down properly and hangs Python on exit (we're trying to use an atexit handler to manage sessions). To fix this I've added our own keepalive ping system which makes use of the connection tracker we already have, which should do until the underlying issues in omero-py are resolved.

Basic test script:

```
import omero2pandas
import time

print("Starting test")
connector = omero2pandas.connect_to_omero(allow_token=False, server=<server>, username=<user>, password=<pwd>)
client = connector.get_client()
print("Connected:", connector.connected)
time.sleep(5)
print("Complete, shutting down!")
```
Should fail to exit without PR, but exit properly with.