### PR TITLE
Make OMERO object column detection case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ ann_id = omero2pandas.upload_table(my_data, "Name for table",
 Once uploaded, the table will be accessible on OMERO.web under the file 
 annotations panel of the parent object. Using unique table names is advised.
 
+### OMERO ID columns
+
+OMERO.tables support some special column types which associate tabular data 
+with objects on the server. These are defined as integer columns with the 
+following names: `project`, `dataset`, `image`, `screen`, `plate`, `well` and 
+`roi`. These names are case-insensitive. For example, a row with an `Image` 
+column with the value `1033` will be associated with Image 1033.
+
+To display this in omero-web the table itself should be linked to either the 
+object itself or a parent container. i.e. If you have an `image` column 
+referencing several images in a dataset, attach the table itself to the parent 
+dataset and the relevant row data will be visible when viewing the 
+individual images in omero-web.
+
 ### Linking to multiple objects
 
 To link to multiple objects, you can supply a list of `(<type>, <id>)`

--- a/omero2pandas/upload.py
+++ b/omero2pandas/upload.py
@@ -72,8 +72,8 @@ def generate_omero_columns(df):
     string_columns = []
     for column_name, column_type in df.dtypes.items():
         cleaned_name = column_name.replace('/', '\\')
-        if column_name in SPECIAL_NAMES and column_type.kind == 'i':
-            col_class = SPECIAL_NAMES[column_name]
+        if column_name.lower() in SPECIAL_NAMES and column_type.kind == 'i':
+            col_class = SPECIAL_NAMES[column_name.lower()]
         elif column_type.kind in COLUMN_TYPES:
             col_class = COLUMN_TYPES[column_type.kind]
         else:


### PR DESCRIPTION
Currently in CSV mode an OMERO object column must be named in lower case to be picked up and registered as a formal object column. This PR makes this detection case-insensitive, so a column called `ROI` becomes an ROIColumn instead of requiring it be named `roi`.