### PR TITLE
Use native omero-py keepalive system

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,6 @@ reconnecting). This can be disabled as follows
 omero2pandas.connect_to_omero(keep_alive=False)
 ```
 
-N.b. omero2pandas uses a different system from the native OMERO API's
-`client.enableKeepAlive` function, using both is unnecessary.
-
 ### Querying tables
 
 You can also supply [PyTables condition syntax](https://www.pytables.org/usersguide/condition_syntax.html) to the `read_table` and `download_table` functions.

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'omero-py',
+        'omero-py>=5.19.5',
         'pandas',
         'tqdm',
     ],


### PR DESCRIPTION
Now that the shutdown deadlock bug has been fixed upstream we can drop the internal keepalive system in favour of pinning to the latest `omero-py` release.