### PR TITLE
Add initial remote table registration implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,14 +273,15 @@ replacing tricky elements with a variable may help.
 
 ### Remote registration [Experimental]
 
-For OMERO installations which support TileDB as the OMERO.tables backend it 
-is possible to register tables in-place in a similar manner to in-place image 
+For **OMERO Plus** installations which support TileDB as the OMERO.tables backend 
+it is possible to register tables in-place in a similar manner to in-place image 
 imports (otherwise table data is stored in the ManagedRepository).
 
-If you don't know what table backend your OMERO server is using, you probably 
-don't have this feature available. If you have access to the server machine you 
-can check by running `omero config get omero.tables.module`, if the response is 
-`omero_plus.run_tables_pytables_or_tiledb` then tiledb is available.
+If you don't know what table backend your OMERO Plus server is using, you 
+probably don't have this feature available. If you have access to the server 
+machine you can check by running `omero config get omero.tables.module`, 
+if the response is `omero_plus.run_tables_pytables_or_tiledb` then tiledb is 
+available.
 
 This feature is currently in active development. The current version of 
 omero2pandas can export tables locally in TileDB format to be registered with 

--- a/README.md
+++ b/README.md
@@ -277,8 +277,10 @@ For OMERO installations which support TileDB as the OMERO.tables backend it
 is possible to register tables in-place in a similar manner to in-place image 
 imports (otherwise table data is stored in the ManagedRepository).
 
-N.b. If you don't know what table backend your OMERO server is using, you probably 
-don't have this feature available.
+If you don't know what table backend your OMERO server is using, you probably 
+don't have this feature available. If you have access to the server machine you 
+can check by running `omero config get omero.tables.module`, if the response is 
+`omero_plus.run_tables_pytables_or_tiledb` then tiledb is available.
 
 This feature is currently in active development. The current version of 
 omero2pandas can export tables locally in TileDB format to be registered with 

--- a/README.md
+++ b/README.md
@@ -270,3 +270,40 @@ These should match the relevant column type. Mapped variables are substituted in
 
 A `variables` map usually isn't needed for simple queries. The basic condition string should automatically get converted to a meaningful type, but when this fails 
 replacing tricky elements with a variable may help.
+
+### Remote registration [Experimental]
+
+For OMERO installations which support TileDB as the OMERO.tables backend it 
+is possible to register tables in-place in a similar manner to in-place image 
+imports (otherwise table data is stored in the ManagedRepository).
+
+N.b. If you don't know what table backend your OMERO server is using, you probably 
+don't have this feature available.
+
+This feature is currently in active development. The current version of 
+omero2pandas can export tables locally in TileDB format to be registered with 
+OMERO using external tooling.
+
+
+For this mode to be available extra dependencies must also be installed as follows
+
+```bash
+pip install omero2pandas[remote]
+```
+
+To activate this mode use `omero2pandas.upload_table` with arguments as 
+follows:
+
+```python
+import omero2pandas
+db_path = omero2pandas.upload_table("/path/to/my_data.csv", "Name for table", 
+                                    local_path="/path/to/mytable.tiledb")
+# Returns the path to the created tiledb file
+```
+
+Similar to regular table uploads, the input can be a dataframe in memory or a 
+csv file on disk.
+
+A `remote_path` argument is also available. In future versions this will be 
+used if the remote table path is different from the server's point of view (e.g. 
+network drives are mapped at another location).

--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -242,8 +242,9 @@ def upload_table(source, table_name, parent_id=None, parent_type='Image',
         if local_path or remote_path:
             if not register_table:
                 raise ValueError("Remote table support is not installed")
-            ann_id = register_table(
-                source, chunk_size, local_path, remote_path)
+            ann_id = register_table(source, local_path,
+                                    remote_path=remote_path,
+                                    chunk_size=chunk_size)
         else:
             ann_id = create_table(source, table_name, links, conn, chunk_size)
         if ann_id is None:

--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -242,9 +242,8 @@ def upload_table(source, table_name, parent_id=None, parent_type='Image',
         if local_path or remote_path:
             if not register_table:
                 raise ValueError("Remote table support is not installed")
-            ann_id = register_table(source, table_name, links,
-                                    connector.server, chunk_size,
-                                    local_path, remote_path)
+            ann_id = register_table(
+                source, chunk_size, local_path, remote_path)
         else:
             ann_id = create_table(source, table_name, links, conn, chunk_size)
         if ann_id is None:

--- a/omero2pandas/remote.py
+++ b/omero2pandas/remote.py
@@ -1,0 +1,44 @@
+# encoding: utf-8
+#
+# Copyright (c) Glencoe Software, Inc. All rights reserved.
+#
+# This software is distributed under the terms described by the LICENCE file
+# you can find at the root of the distribution bundle.
+# If the file is missing please request a copy by contacting
+# support@glencoesoftware.com.
+import logging
+from pathlib import Path, PurePosixPath
+import time
+
+import tiledb
+
+LOGGER = logging.getLogger(__name__)
+
+OMERO_TILEDB_VERSION = '3'  # Version of the omero table implementation
+
+
+def register_table(source, chunk_size, local_path, remote_path):
+    LOGGER.info("Registering remote table")
+    # Default filters from tiledb.from_pandas()
+    write_path = Path(local_path or remote_path).with_suffix(".tiledb")
+    # Assume the server will be running on Linux
+    remote_path = PurePosixPath(
+        remote_path or local_path).with_suffix(".tiledb")
+    LOGGER.debug(f"Remote path would be {str(remote_path)}")
+    if write_path.exists():
+        raise ValueError(f"Table file {write_path} already exists")
+    # path.as_uri() exists but mangles any spaces in the path!
+    write_path = str(write_path)
+    LOGGER.info("Writing data to TileDB")
+    # Export table
+    if isinstance(source, (str, Path)):
+        tiledb.from_csv(write_path, source, chunksize=chunk_size)
+    else:
+        tiledb.from_pandas(write_path, source, chunksize=chunk_size)
+    LOGGER.debug("Appending metadata to TileDB")
+    # Append omero metadata
+    with tiledb.open(write_path, mode="w") as array:
+        array.meta['__version'] = OMERO_TILEDB_VERSION
+        array.meta['__initialized'] = time.time()
+    LOGGER.info("Table saved successfully")
+    return write_path

--- a/omero2pandas/remote.py
+++ b/omero2pandas/remote.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 OMERO_TILEDB_VERSION = '3'  # Version of the omero table implementation
 
 
-def register_table(source, chunk_size, local_path, remote_path):
+def register_table(source, local_path, remote_path=None, chunk_size=1000):
     LOGGER.info("Registering remote table")
     # Default filters from tiledb.from_pandas()
     write_path = Path(local_path or remote_path).with_suffix(".tiledb")

--- a/omero2pandas/remote.py
+++ b/omero2pandas/remote.py
@@ -31,6 +31,8 @@ def register_table(source, chunk_size, local_path, remote_path):
         raise ValueError(f"Table file {write_path} already exists")
     # path.as_uri() exists but mangles any spaces in the path!
     write_path = str(write_path)
+    # Use a default chunk size if not set
+    chunk_size = chunk_size or 1000
     LOGGER.info("Writing data to TileDB")
     # Export table
     if isinstance(source, (str, Path)):

--- a/omero2pandas/upload.py
+++ b/omero2pandas/upload.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright (c) 2023 Glencoe Software, Inc. All rights reserved.
+# Copyright (c) Glencoe Software, Inc. All rights reserved.
 #
 # This software is distributed under the terms described by the LICENCE file
 # you can find at the root of the distribution bundle.
@@ -9,6 +9,7 @@
 import logging
 import math
 import os
+from pathlib import Path
 
 import omero
 import omero.grid
@@ -170,7 +171,7 @@ def create_table(source, table_name, links, conn, chunk_size):
         bar_format='{desc}: {percentage:3.0f}%|{bar}| '
                    '{n_fmt}/{total_fmt} rows, {elapsed} {postfix}')
 
-    if isinstance(source, str):
+    if isinstance(source, (str, Path)):
         assert os.path.exists(source), f"Could not find file {source}"
         columns, str_cols, total_rows, chunk_size = generate_omero_columns_csv(
             source, chunk_size)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,6 @@ name = "omero2pandas"
 description = "OMERO.tables to pandas bridge"
 readme = "README.md"
 license = {file = "LICENSE.txt"}
-dependencies = [
-    'omero-py>=5.19.5',
-    'pandas>2',
-    'tqdm',
-]
-requires-python = ">=3.9"
 authors = [
     {name = "Glencoe Software, Inc.", email="info@glencoesoftware.com"},
 ]
@@ -25,10 +19,19 @@ classifiers = [
     'Intended Audience :: End Users/Desktop',
     'Programming Language :: Python :: 3',
 ]
-
+requires-python = ">=3.9"
+dependencies = [
+    'omero-py>=5.19.5',
+    'pandas>2',
+    'tqdm',
+]
 
 [project.optional-dependencies]
 token = ["omero-user-token>=0.3.0"]
+remote = [
+    "pyarrow>=19.0.0",
+    "tiledb>=0.33.2",
+]
 
 [project.urls]
 github = "https://github.com/glencoesoftware/omero2pandas"


### PR DESCRIPTION
This PR begins work towards a mechanism for registering tables without uploading the data to the OMERO Managed Repository, so as to allow users to store table data elsewhere.

Per internal discussions this initial version operates offline. omero2pandas will create a local tiledb file and return the path, which the user should register with OMERO using external tooling. Future work will add a system for doing this registration automatically.

I've tried to match the omero-plus schema as closely as possible. Some testing for compatibility needs to be done.

N.b. For any of this to be useful the OMERO server must have the TileDB OMERO.tables backend installed. PyTables is the default backend. 

## Installation

```bash
pip install omero2pandas[remote]
```


## Usage

```python
import omero2pandas
omero2pandas.upload_table(csv_or_dataframe, table_name, local_path="/path/to/my_table.tiledb")
```

Due to constraints in the API this will require an OMERO login. To test offline do the following:

```python
from omero2pandas.remote import register_table
register_table(csv_or_dataframe, chunk_size, local_path="/path/to/my_table.tiledb", remote_path=None)
```
`chunk_size` denotes how much data to load/save in a single operation, `remote_path` will eventually be used to provide a server-visible version of `local_path` when performing the upload from a different machine than the OMERO server.
