### PR TITLE
Drop logging configuration settings

### DIFF
--- a/omero2pandas/__init__.py
+++ b/omero2pandas/__init__.py
@@ -10,7 +10,6 @@ import collections
 from importlib.util import find_spec
 import logging
 import os
-import sys
 from typing import Iterable
 
 import pandas
@@ -24,10 +23,6 @@ if find_spec("tiledb"):
     from omero2pandas.remote import register_table
 else:
     register_table = None
-
-logging.basicConfig(
-    format="%(asctime)s %(levelname)-7s [%(name)16s] %(message)s",
-    stream=sys.stdout)
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR addresses two problems:

- omero2pandas currently applies configuration to the root logger, which may interfere with configuration performed by end users. It should probably be left up to the consuming application to do this.
- The applied configuration does not specify a log level, meaning that it'll default to only showing `WARNING` and above. This can lead to a counterintuitive scenario where the user expects to see `INFO` messages, but omero2pandas has suppressed them.

I think the solution here is to not be opinionated about logging format at all. We'll let omero2pandas use whatever was configured by the application calling it. Since we (currently?) don't offer a CLI we shouldn't need to touch the root logger ourselves.

## Testing

Make a simple test script:
```python
import logging
import omero2pandas

logger = logging.getLogger(__name__)
logging.basicConfig(level=logging.DEBUG, format='%(levelname)-7s %(message)s')

logger.info("Foo")
logger.warning("Bar")
```

When run this produces:

```bash
2025-02-19 15:04:52,249 WARNING [        __main__] Bar
```

This happens as omero2pandas applied it's logging settings.

Comment out `import omero2pandas` and you should get:

```bash
INFO    Foo
WARNING Bar

```

With this PR you should always get the latter result.