### PR TITLE
Expand supported link types

### DIFF
--- a/omero2pandas/upload.py
+++ b/omero2pandas/upload.py
@@ -56,6 +56,11 @@ OBJECT_TYPES = {
     "Screen": omero.model.ScreenI,
     "Well": omero.model.WellI,
     "Roi": omero.model.RoiI,
+    "FileAnnotation": omero.model.FileAnnotationI,
+    "ListAnnotation": omero.model.ListAnnotationI,
+    "MapAnnotation": omero.model.MapAnnotationI,
+    "TagAnnotation": omero.model.TagAnnotationI,
+    "XmlAnnotation": omero.model.XmlAnnotationI,
 }
 
 
@@ -151,7 +156,8 @@ def create_table(source, table_name, links, conn, chunk_size):
                                       f"supported as a link target")
         if target_type != "Roi":
             roi_only = False
-        target_ob = conn.getObject(target_type, target_id)
+        target_ob = conn.getQueryService().find(target_type, target_id,
+                                                {"omero.group": "-1"})
         if target_ob is None:
             raise ValueError(f"{target_type} #{target_id} not found")
         target_group = target_ob.details.group.id.val
@@ -225,7 +231,10 @@ def create_table(source, table_name, links, conn, chunk_size):
             annotation_obj.id.val, False)
         link_buffer = []
         for obj_type, obj_id in links:
-            link_obj = LINK_TYPES[obj_type]()
+            if "annotation" in obj_type.lower():
+                link_obj = omero.model.AnnotationAnnotationLinkI()
+            else:
+                link_obj = LINK_TYPES[obj_type]()
             unloaded_target = OBJECT_TYPES[obj_type](obj_id, False)
             link_obj.link(unloaded_target, unloaded_annotation)
             link_buffer.append(link_obj)

--- a/omero2pandas/upload.py
+++ b/omero2pandas/upload.py
@@ -56,10 +56,16 @@ OBJECT_TYPES = {
     "Screen": omero.model.ScreenI,
     "Well": omero.model.WellI,
     "Roi": omero.model.RoiI,
+    "BooleanAnnotation": omero.model.BooleanAnnotationI,
+    "CommentAnnotation": omero.model.CommentAnnotationI,
+    "DoubleAnnotation": omero.model.DoubleAnnotationI,
     "FileAnnotation": omero.model.FileAnnotationI,
     "ListAnnotation": omero.model.ListAnnotationI,
+    "LongAnnotation": omero.model.LongAnnotationI,
     "MapAnnotation": omero.model.MapAnnotationI,
     "TagAnnotation": omero.model.TagAnnotationI,
+    "TermAnnotation": omero.model.TermAnnotationI,
+    "TimestampAnnotation": omero.model.TimestampAnnotationI,
     "XmlAnnotation": omero.model.XmlAnnotationI,
 }
 
@@ -145,8 +151,9 @@ def generate_omero_columns_csv(csv_path, chunk_size=1000):
 
 def create_table(source, table_name, links, conn, chunk_size):
     # Create an OMERO.table and upload data
-    # Make type case-insensitive
-    links = [(t.lower().capitalize(), i) for t, i in links]
+    # Make type case-insensitive, handling annotation caps properly
+    links = [(t.lower().capitalize().replace("annotation", "Annotation"), i)
+             for t, i in links]
     # Validate link list
     working_group = None
     roi_only = True


### PR DESCRIPTION
This PR expands the object types permitted in the `links` argument to cover some annotation types. This will primarily help to associate results with the workflow data model.

We could potentially include some of the more obscure types like `BooleanAnnotation` but I've tried to limit it to what is likely to be useful within omero-web, at least in the first instance.