### PR TITLE
Improve handling of different connection types

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ When a client is active within the `OMEROConnection` object, calls to this wrapp
 OMEROConnection objects can also be used as a context manager:
 ```python
 import omero2pandas
-with omero2pandas.OMEROConnection(server='my.server', port=4064, 
-                                  username='test.user',) as connector:
+with omero2pandas.connect_to_omero(server='my.server', port=4064, 
+                                   username='test.user',) as connector:
     blitz = connector.get_gateway()
     image = blitz.getObject('Image', id=100)
     # Continue using the standard OMERO API.

--- a/omero2pandas/remote.py
+++ b/omero2pandas/remote.py
@@ -17,6 +17,8 @@ import tiledb
 from requests import HTTPError
 from tqdm.auto import tqdm
 
+from omero2pandas.connect import get_connection
+
 LOGGER = logging.getLogger(__name__)
 
 OMERO_TILEDB_VERSION = '3'  # Version of the omero table implementation
@@ -97,6 +99,8 @@ def create_tiledb(source, output_path, chunk_size=1000):
 
 def register_table(connector, remote_path, table_name, links, token,
                    prefix=""):
+    # Check we got the correct connector type
+    connector = get_connection(client=connector)
     if not connector.server:
         raise ValueError("Unknown server? This should never happen!")
     server = f"https://{connector.server}"


### PR DESCRIPTION
A few changes here aimed at making the experience of using the connector interface a bit smoother. Overall goal is to allow users to supply either an OMEROConnection, BlitzGateway or omero.client object when interacting with omero2pandas using an existing connection.

- Moved `get_connection` to the `omero2pandas.connect` module to better isolate it. Removed the underscore prefix to make this a bit more public. The basic gist of this function is to create a new OMEROConnection object using the supplied params, but avoid creating a nested object if the user already supplied an existing OMEROConnection instance.
- If the user supplies an existing BlitzGateway as the client we now handle this properly.
- `omero2pandas.remote.register_table` now supports client/blitzgateway objects, not just OMEROConnections.
-  We no longer `detachOnDestroy` new sessions created just for the o2p connector.