### PR TITLE
Writing tables to private groups

### DIFF
--- a/omero2pandas/upload.py
+++ b/omero2pandas/upload.py
@@ -227,7 +227,7 @@ def create_table(source, table_name, links, conn, chunk_size):
         orig_file = table.getOriginalFile()
         # Create FileAnnotation from OriginalFile
         annotation = omero.model.FileAnnotationI()
-        annotation.file = orig_file
+        annotation.file = omero.model.OriginalFileI(orig_file.id.val, False)
         annotation_obj = conn.getUpdateService().saveAndReturnObject(
             annotation, {"omero.group": str(working_group)})
         LOGGER.info(f"Generated FileAnnotation {annotation_obj.id.val} "


### PR DESCRIPTION
This PR addresses an issue where an OriginalFile object created during table registration may incorrectly reference an ExternalInfo object owned by another user, rather than the active OMERO user. This generally goes unnoticed in shared groups (Read-Only, Read-Annotate, Read-Write), as read access is permitted across users. However, it leads to a SecurityViolation in private groups, where cross-user access is restricted.

```python
import omero2pandas
db_path = omero2pandas.upload_table("example.csv", "testing", parent_id=123, parent_type="Image")
```
To resolve this, the change introduces a shallow copy of the OriginalFile using a newly constructed OriginalFileI object. This ensures that ownership and related metadata are correctly set to match the current user context at creation time.
