### PR TITLE
Fixes download for OMERO table

### DIFF
--- a/omero2pandas/io_tools.py
+++ b/omero2pandas/io_tools.py
@@ -144,6 +144,6 @@ def infer_compression(mimetype, name):
     mimetype = mimetype.lower()
     if mimetype == "application/x-gzip":
         return "gzip"
-    elif mimetype == "text/csv":
+    elif mimetype == "text/csv" or mimetype == "omero.tables":
         return None
     raise ValueError(f"Unsupported mimetype: {mimetype}")


### PR DESCRIPTION
This PR fixes #36 and allows to read and download omero tables with Mimetype `omero.tables`.
