### PR TITLE
TileDB writer performance improvements

### DIFF
--- a/omero2pandas/remote.py
+++ b/omero2pandas/remote.py
@@ -85,7 +85,7 @@ def create_tiledb(source, output_path, chunk_size=10000, cleanup=False):
             tiledb.from_pandas(output_path, source, sparse=True,
                                full_domain=True, dim_filters=filters,
                                attr_filters=None, chunksize=chunk_size,
-                               allow_duplicates=False)
+                               allows_duplicates=False)
         if cleanup:
             bar.set_description("Optimising TileDB file...")
             tiledb.consolidate(output_path)


### PR DESCRIPTION
We previously tried to use a chunked writing approach to keep things as similar to the pytables writing API as possible. However in practice this had a few unintended consequences. Chunked writes into a tiledb create fragments which impact performance when trying to read the table. Our previous default chunk size was set arbitrarily and ended up being small (1000).

This PR makes a few revisions to improve things:

- Default chunk size to 10,000
- Add the Zstd compression filter which is applied by the native omero-plus generator.
- Use the native chunking from tiledb's `from_pandas` method instead of doing so manually. This gives us better performance at the expense of losing granular progress tracking (there is no progress hook).
- Add an optional consolidation/vacuum step after tiledb construction to clean up fragments (`cleanup=True`). Not sure if we want to expose this to the main entry point yet but it's there when calling the remote module directly. This is disabled by default to match previous functionality, we should evaluate whether this is necessary for typical workflows as it's an expensive process.

There's a broader question on whether we should try to figure out chunk size automatically somehow. It's not clear what provides optional performance with TileDB so we might need to investigate further.

For testing, try uploading a remote table starting with both a pandas dataframe in memory and a csv file on disk. Both should register without issues. 