### PR TITLE
Pin tiledb version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 token = ["omero-user-token>=0.3.0"]
 remote = [
     "pyarrow>=19.0.0",
-    "tiledb>=0.33.2",
+    "tiledb>=0.33.2, <0.34.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes #41

Looks like there's a bug in recent TileDB versions which is interfering with the indexing in sparse csvs uploaded in chunked fashion. For now we'll pin to below the version that introduced the bug.